### PR TITLE
Browser support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 .DS_Store
 TAGS
+dist
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.0 - 2019-xx-xx
 
-### Addded
+### Added
 - Build and distribute static browser version with all contexts.
 - Export a `contexts` Map associating ids to contexts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Added
 - Build and distribute static browser version with all contexts.
-- Export a `contexts` Map associating ids to contexts.
+- Export a `contexts` Map associating context URIs to contexts.
+- Export a `constants` Object associating short ids to contexts URIs.
 
 ### Removed
-- **BREAKING**: Remove exported `v1` and `v2` in favor of new `contexts` Map.
+- **BREAKING**: Remove exported `v1` and `v2` in favor of new `contexts` Map
+  and `constants` Object.
 
 ## 2.0.0 - 2019-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # security-context ChangeLog
 
+## 3.0.0 - 2019-xx-xx
+
+### Addded
+- Build and distribute static browser version with all contexts.
+- Export a `contexts` Map associating ids to contexts.
+
+### Removed
+- **BREAKING**: Remove exported `v1` and `v2` in favor of new `contexts` Map.
+
 ## 2.0.0 - 2019-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+Security Vocabulary
+===================
+
+This repository contains the [Digital Verification Community Group][DVCG]
+Security Vocabulary and a [npm package][security-context] that exports related
+contexts and constants.
+
+Security Vocabulary
+-------------------
+
+Security Vocabulary specification https://w3c-dvcg.github.io/security-vocab/.
+
+Context Package
+---------------
+
+The repository contains [JSON-LD][] contexts for the Security Vocabulary.
+These are also packaged in a [npm package][security-contexts] for CommonJS and
+ES Modules.  To use with NPM and Node.js, use the following:
+
+```
+npm install security-context
+```
+
+The package exposes two values:
+- `contexts`: A Map from context URI to JSON-LD context.
+- `constants`: An Object of shorthand keys mapped to context URIs.
+
+```js
+const {contexts, constants} = require('security-context');
+```
+
+With ES Modules:
+```js
+// use one of the following forms:
+import * as securityvocab1 from 'security-context';
+import {default as securityvocab2} from 'security-context';
+import {contexts, constants} from 'security-context';
+```
+
+[DVCG]: https://w3c-dvcg.github.io/
+[JSON-LD]: https://json-ld.org/
+[security-context]: https://www.npmjs.com/package/security-context

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ contexts and constants.
 Security Vocabulary
 -------------------
 
-Security Vocabulary specification https://w3c-dvcg.github.io/security-vocab/.
+Security Vocabulary specification: https://w3c-dvcg.github.io/security-vocab/.
 
 Context Package
 ---------------
 
 The repository contains [JSON-LD][] contexts for the Security Vocabulary.
-These are also packaged in a [npm package][security-contexts] for CommonJS and
+These are also packaged in a [npm package][security-context] for CommonJS and
 ES Modules.  To use with NPM and Node.js, use the following:
 
 ```

--- a/js/browser.js
+++ b/js/browser.js
@@ -1,10 +1,13 @@
 'use strict';
 
-const contexts = exports.contexts = new Map();
+import {constants} from './constants.js';
+const contexts = new Map();
 
 contexts.set(
-  'https://w3id.org/security/v1',
+  constants.SECURITY_CONTEXT_V1_URL,
   require('../contexts/security-v1.jsonld'));
 contexts.set(
-  'https://w3id.org/security/v2',
+  constants.SECURITY_CONTEXT_V2_URL,
   require('../contexts/security-v2.jsonld'));
+
+export {constants, contexts};

--- a/js/browser.js
+++ b/js/browser.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import {constants} from './constants.js';
-const contexts = new Map();
+const contexts = exports.contexts = new Map();
+const constants = exports.constants = require('./constants.js');
 
 contexts.set(
   constants.SECURITY_CONTEXT_V1_URL,
@@ -9,5 +9,3 @@ contexts.set(
 contexts.set(
   constants.SECURITY_CONTEXT_V2_URL,
   require('../contexts/security-v2.jsonld'));
-
-export {constants, contexts};

--- a/js/browser.js
+++ b/js/browser.js
@@ -1,4 +1,10 @@
 'use strict';
 
-exports.v1 = require('../contexts/security-v1.json');
-exports.v2 = require('../contexts/security-v2.json');
+const contexts = exports.contexts = new Map();
+
+contexts.set(
+  'https://w3id.org/security/v1',
+  require('../contexts/security-v1.jsonld'));
+contexts.set(
+  'https://w3id.org/security/v2',
+  require('../contexts/security-v2.jsonld'));

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const constants = exports.constants = {};
+
+constants.SECURITY_CONTEXT_V1_URL = 'https://w3id.org/security/v1';
+constants.SECURITY_CONTEXT_V2_URL = 'https://w3id.org/security/v2';

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,4 @@
 'use strict';
 
-const constants = exports.constants = {};
-
-constants.SECURITY_CONTEXT_V1_URL = 'https://w3id.org/security/v1';
-constants.SECURITY_CONTEXT_V2_URL = 'https://w3id.org/security/v2';
+exports.SECURITY_CONTEXT_V1_URL = 'https://w3id.org/security/v1';
+exports.SECURITY_CONTEXT_V2_URL = 'https://w3id.org/security/v2';

--- a/js/index.js
+++ b/js/index.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const {constants} = require('./constants');
 const fs = require('fs');
 const path = require('path');
 
+exports.constants = constants;
 const contexts = exports.contexts = new Map();
 
 function _read(_path) {
@@ -13,8 +15,8 @@ function _read(_path) {
 }
 
 contexts.set(
-  'https://w3id.org/security/v1',
+  constants.SECURITY_CONTEXT_V1_URL,
   _read('../contexts/security-v1.jsonld'));
 contexts.set(
-  'https://w3id.org/security/v2',
+  constants.SECURITY_CONTEXT_V2_URL,
   _read('../contexts/security-v2.jsonld'));

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {constants} = require('./constants');
+const constants = require('./constants');
 const fs = require('fs');
 const path = require('path');
 

--- a/js/index.js
+++ b/js/index.js
@@ -3,12 +3,18 @@
 const fs = require('fs');
 const path = require('path');
 
-exports.v1 = JSON.parse(
-  fs.readFileSync(
-    path.join(__dirname, '../contexts/security-v1.jsonld'),
-    {encoding: 'utf8'}));
+const contexts = exports.contexts = new Map();
 
-exports.v2 = JSON.parse(
-  fs.readFileSync(
-    path.join(__dirname, '../contexts/security-v2.jsonld'),
-    {encoding: 'utf8'}));
+function _read(_path) {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, _path),
+      {encoding: 'utf8'}));
+}
+
+contexts.set(
+  'https://w3id.org/security/v1',
+  _read('../contexts/security-v1.jsonld'));
+contexts.set(
+  'https://w3id.org/security/v2',
+  _read('../contexts/security-v2.jsonld'));

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "2.0.1-0",
   "description": "Security Context",
   "main": "js",
-  "browser": "./dist/main.js",
+  "module": "./dist/module.js",
   "files": [
     "contexts",
-    "dist/main.js",
+    "dist/module.js",
     "js/index.js"
   ],
   "repository": {
@@ -19,11 +19,13 @@
   "homepage": "https://w3c-dvcg.github.io/security-vocab/",
   "devDependencies": {
     "json-loader": "^0.5.7",
+    "rollup": "^1.11.3",
+    "rollup-plugin-commonjs": "^9.3.4",
     "webpack": "^4.30.0",
-    "webpack-cli": "^3.3.0"
+    "webpack-cli": "^3.3.2"
   },
   "scripts": {
     "prepublish": "npm run build",
-    "build": "webpack"
+    "build": "webpack && rollup -c"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,14 +3,11 @@
   "version": "2.0.1-0",
   "description": "Security Context",
   "main": "js",
-  "browser": {
-    "./js/index.js": "./js/browser.js",
-    "./contexts/security-v1.json": "./contexts/security-v1.jsonld",
-    "./contexts/security-v2.json": "./contexts/security-v2.jsonld"
-  },
+  "browser": "./dist/main.js",
   "files": [
     "contexts",
-    "js"
+    "dist/main.js",
+    "js/index.js"
   ],
   "repository": {
     "type": "git",
@@ -19,5 +16,14 @@
   "bugs": {
     "url": "https://github.com/w3c-dvcg/security-vocab/issues"
   },
-  "homepage": "https://w3c-dvcg.github.io/security-vocab/"
+  "homepage": "https://w3c-dvcg.github.io/security-vocab/",
+  "devDependencies": {
+    "json-loader": "^0.5.7",
+    "webpack": "^4.30.0",
+    "webpack-cli": "^3.3.0"
+  },
+  "scripts": {
+    "prepublish": "npm run build",
+    "build": "webpack"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  input: 'dist/main.js',
+  output: {
+    file: 'dist/module.js',
+    format: 'esm'
+  },
+  plugins: [
+    commonjs({
+      // explicitly list exports otherwise only have 'default'
+      namedExports: {
+        'dist/main.js': ['contexts', 'constants']
+      }
+    })
+  ]
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  output: {
+    library: 'securityvocab'
+  },
   mode: 'production',
   entry: './js/browser.js',
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  mode: 'production',
+  entry: './js/browser.js',
+  module: {
+    rules: [
+      {
+        test: /\.jsonld$/,
+        loader: 'json-loader'
+      }
+    ]
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   output: {
-    library: 'securityvocab'
+    libraryTarget: 'commonjs'
   },
   mode: 'production',
   entry: './js/browser.js',


### PR DESCRIPTION
- Build and distribute static browser version with all contexts.
- Export a `contexts` Map associating ids to contexts.
- Remove exported `v1` and `v2` in favor of new `contexts` Map.

This changes to a standard Map interface exposed as `contexts`.  That would allow get, has, keys, entries, etc.  Using the `contexts` property so the top level could potential include other properties such as the default id.